### PR TITLE
Update main.tf locals.tags to use tomap - Terraform > 0.12 support

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ data "aws_caller_identity" "current" {}
 locals {
   prefix = var.prefix_resource != "" ? "${var.prefix_resource}-" : ""
   function_name = "${local.prefix}sns-to-teams"
-  tags          = merge(var.tags, map("Lambda", local.function_name))
+  tags          = merge(var.tags, tomap({"Lambda" = local.function_name}))
 }
 
 resource "aws_cloudwatch_log_group" "this" {


### PR DESCRIPTION
replaces the map function with tomap as it is deprecated after terraform 0.12